### PR TITLE
align TLS cert/key env vars to TLS_CERT_PATH/TLS_KEY_PATH

### DIFF
--- a/cmd/spell/main.go
+++ b/cmd/spell/main.go
@@ -52,11 +52,11 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "cert-file",
-				Sources: cli.EnvVars("TLS_CERT"),
+				Sources: cli.EnvVars("TLS_CERT_PATH"),
 			},
 			&cli.StringFlag{
 				Name:    "key-file",
-				Sources: cli.EnvVars("TLS_KEY"),
+				Sources: cli.EnvVars("TLS_KEY_PATH"),
 			},
 			&cli.StringFlag{
 				Name:    "log-level",


### PR DESCRIPTION
Aligns the TLS cert/key flag env var names with `TLS_CERT_PATH`/`TLS_KEY_PATH` as used by helm-elib's go deployment template, matching the pattern in elephant-repository and the other Go services.